### PR TITLE
(fix) split on \n, not \r\n

### DIFF
--- a/redirect.php
+++ b/redirect.php
@@ -75,7 +75,7 @@ function dxw_members_only_ip_in_range($ip, $range)
 
 function dxw_members_only_current_ip_in_whitelist()
 {
-    $ip_list = explode("\r\n", get_option('dxw_members_only_ip_whitelist'));
+    $ip_list = explode("\n", get_option('dxw_members_only_ip_whitelist'));
     foreach ($ip_list as $ip) {
         if (!empty($ip) && dxw_members_only_ip_in_range($_SERVER['REMOTE_ADDR'], $ip)) {
             return true;
@@ -125,7 +125,7 @@ add_action('init', function () {
 
     // List
     $hit = false;
-    $list = explode("\r\n", get_option('dxw_members_only_list_content'));
+    $list = explode("\n", get_option('dxw_members_only_list_content'));
 
     foreach ($list as $w) {
         $w = trim($w);

--- a/redirect.php
+++ b/redirect.php
@@ -77,6 +77,7 @@ function dxw_members_only_current_ip_in_whitelist()
 {
     $ip_list = explode("\n", get_option('dxw_members_only_ip_whitelist'));
     foreach ($ip_list as $ip) {
+        $ip = trim($ip);
         if (!empty($ip) && dxw_members_only_ip_in_range($_SERVER['REMOTE_ADDR'], $ip)) {
             return true;
         }


### PR DESCRIPTION
Splitting on \r\n seems to work when entering data through the browser. However, when configuring the plugin via wp-cli on a mac, the lines are separated only with \n, so although they get displayed on multiple lines in the admin, they don't get interpreted correctly by new_members-only.

trim will remove any \r if present.