### PR TITLE
Fix deprecation of dynamic properties for PHP8.2

### DIFF
--- a/dmometasettings.php
+++ b/dmometasettings.php
@@ -1,6 +1,11 @@
 <?php
 class dmometasettings
 {
+    public $file;
+    public $plugin;
+    public $settings;
+    public $namespace;
+
     public function __construct($file, $namespace)
     {
         $this->file = $file;

--- a/dxw-members-only.php
+++ b/dxw-members-only.php
@@ -3,7 +3,7 @@
  * Plugin Name: dxw Members Only
  * Plugin URI: http://dxw.com
  * Description: Make your WordPress site visible to signed-in users only with the added ability to whitelist specific content for access by all users.
- * Version: 4.1.0
+ * Version: 4.1.1
  * Author: dxw
  * Author URI: http://dxw.com
  * Text Domain: dxwmembersonly


### PR DESCRIPTION
- [x] Version number has been bumped

PHP 8.2 has introduced stricter rules regarding dynamic properties in classes. 
Previously, this component used dynamic properties, which are no longer supported in PHP 8.2. 
As a result, sites using this plugin were encountering deprecation errors when they upgraded to PHP 8.2.

<img width="1283" alt="image" src="https://github.com/dxw/dxw-members-only/assets/53922624/0a1d95c0-e8a5-4735-8689-d7b53c0fcd30">


## How to Test
1. Clone and run the latest version of [Bikeshed](https://github.com/dxw/bikeshed)
2. Install Query Monitor (for some reason I'm unable to see the deprecation warnings in my docker logs)
3. Activate the dxw members only plugin
4. Confirm the deprecation warnings are occurring
5. Navigate to `wp-content/plugins/dxw-members-only` and checkout this branch
6. Confirm the deprecation warnings are no longer present