### PR TITLE
Add x-redirect-by header to all redirects

### DIFF
--- a/dxw-members-only.php
+++ b/dxw-members-only.php
@@ -3,7 +3,7 @@
  * Plugin Name: dxw Members Only
  * Plugin URI: http://dxw.com
  * Description: Make your WordPress site visible to signed-in users only with the added ability to whitelist specific content for access by all users.
- * Version: 4.1.1
+ * Version: 4.2.1
  * Author: dxw
  * Author URI: http://dxw.com
  * Text Domain: dxwmembersonly

--- a/redirect.php
+++ b/redirect.php
@@ -50,6 +50,7 @@ function dxw_members_only_redirect($root)
     $redirect = str_replace('%return_path%', urlencode($_SERVER['REQUEST_URI']), $redirect);
 
     header('HTTP/1.1 303 See Other');
+    header('x-redirect-by: dxw-members-only');
     header('Location: '.$redirect);
     die();
 }


### PR DESCRIPTION
When we have incidents or tricky pieces of debugging, it is
often useful to know what part of a WordPress system has
generated an HTTP redirect.

By convention, WordPress sends a header called 'x-redirect-by'
with all redirects, which either contains the third argument
to wp_redirect() / wp_safe_redirect() or the default string
'WordPress'.

Because dxw-members-only does not use the WordPress global
functions to provide redirects, it has no equivalent. So, this
commit adds the 'x-redirect-by' header explicitly.
See: https://developer.wordpress.org/reference/functions/wp_redirect/


- [x] Version number has been bumped
