### PR TITLE
Support 304 responses for uploads

### DIFF
--- a/redirect.php
+++ b/redirect.php
@@ -18,22 +18,33 @@ function dxw_members_only_serve_uploads()
         $realUploadDir = realpath($basedir);
 
         if (is_file($file) && is_readable($file) && \Missing\Strings::startsWith($realFilePath, $realUploadDir.'/')) {
-            $mime = wp_check_filetype($file);
 
-            $type = 'application/octet-stream';
-            if ($mime['type'] !== false) {
-                $type = $mime['type'];
+            $ims_timestamp = gmdate('D, d M Y H:i:s T', filemtime($file));
+
+            if ( $_SERVER['HTTP_IF_MODIFIED_SINCE'] && $ims_timestamp === $_SERVER['HTTP_IF_MODIFIED_SINCE'] ) {
+                ## we don't set Etag so `If-None-Match:` doesn't need checking
+
+                http_response_code(304);
+                header('Last-Modified: ' . $ims_timestamp);
+
+            } else {
+
+                $mime = wp_check_filetype($file);
+                $type = 'application/octet-stream';
+                if ($mime['type'] !== false) {
+                    $type = $mime['type'];
+                }
+
+                header('Accept-Ranges: none');
+                header('Content-Type: ' . $type);
+                header('Content-Length: ' . filesize($file));
+                header('Last-Modified: ' . $ims_timestamp);
+
+                header('X-Accel-Buffering: no');
+
+                ob_get_flush();
+                readfile($file);
             }
-
-            header('Content-Type: ' . $type);
-            header('Content-Length: ' . filesize($file));
-            header('Last-Modified: ' . gmdate('D, d M Y H:i:s T', filemtime($file)));
-            header('Accept-Ranges: none');
-
-            header('X-Accel-Buffering: no');
-
-            ob_get_flush();
-            readfile($file);
             exit;
         }
     }


### PR DESCRIPTION
Now that we're returning a `Last-Modified:` header, we can check any incoming `If-Modified-Since:` header. If the two fields match, then just return a 304.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since

- [ ] Version number has been bumped
