### PR TITLE
Fix/only apply static max age to static content

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ content.
 To create a development build:
 1. Run `composer install` to download dependencies
 
+### Testing locally
+
+1. Install and activate this plugin on a development site
+2. Ensure that requests to `wp-content/uploads` are redirected via PHP as follows (otherwise the plugin will not serve any cache headers for media library files):
+   * Access the WordPress container (usually `script/console` for most of our projects)
+   * `cd /etc/apache2/sites-enabled`
+   * `vi wordpress.conf`, and add the following rewrite rule:
+      ```
+      RewriteRule ^wp-content/uploads/.* index.php [L]
+      ```
+   * Save & exit vi, then `service apache2 reload`
+3. If you want to allow-list your local IP address within the plugin, add `0.0.0.0/0` to the IP allow list in the plugin settings page (this has the effect of allow-listing all IP addresses)
+
 ## Versioning
 
 Please publish and tag new releases when they happen.

--- a/redirect.php
+++ b/redirect.php
@@ -38,7 +38,8 @@ function dxw_members_only_serve_uploads()
 				header('Last-Modified: ' . $ims_timestamp);
 
 				header('X-Accel-Buffering: no');
-
+				$max_age_static = absint(get_option('dxw_members_only_max_age_static'));
+				header('Cache-Control: private, max-age=' . $max_age_static);
 				ob_get_flush();
 				readfile($file);
 			}
@@ -136,7 +137,6 @@ add_action('init', function () {
 	}
 
 	$max_age = absint(get_option('dxw_members_only_max_age'));
-	$max_age_static = absint(get_option('dxw_members_only_max_age_static'));
 	$max_age_public = absint(get_option('dxw_members_only_max_age_public'));
 
 	do_action('dxw_members_only_redirect');
@@ -165,14 +165,14 @@ add_action('init', function () {
 
 	// IP whitelist
 	if (dxw_members_only_current_ip_in_whitelist()) {
-		header('Cache-Control: private, max-age=' . $max_age_static);
+		header('Cache-Control: private, max-age=' . $max_age);
 		dxw_members_only_serve_uploads();
 		return;
 	}
 
 	// Referrer whitelist
 	if (dxw_members_only_referrer_in_allow_list()) {
-		header('Cache-Control: private, max-age=' . $max_age_static);
+		header('Cache-Control: private, max-age=' . $max_age);
 		dxw_members_only_serve_uploads();
 		return;
 	}

--- a/redirect.php
+++ b/redirect.php
@@ -163,15 +163,8 @@ add_action('init', function () {
 		return;
 	}
 
-	// IP whitelist
-	if (dxw_members_only_current_ip_in_whitelist()) {
-		header('Cache-Control: private, max-age=' . $max_age);
-		dxw_members_only_serve_uploads();
-		return;
-	}
-
-	// Referrer whitelist
-	if (dxw_members_only_referrer_in_allow_list()) {
+	// IP & referrer allow lists
+	if (dxw_members_only_current_ip_in_whitelist() || dxw_members_only_referrer_in_allow_list()) {
 		header('Cache-Control: private, max-age=' . $max_age);
 		dxw_members_only_serve_uploads();
 		return;


### PR DESCRIPTION
This PR fixes a bug where requests from behind an allow-listed IP address (or coming from an allow-listed referrer) are served with a cache-control max age of `max_age_static`, which is intended for use only when serving assets from within wp-uploads. 

Those requests are now served with the max age intended for all other requests.

## How to test

1. Spin up a local site and install and activate this plugin. Begin by checking out the `master` branch
2. Check the IP address that is being received by the docker container when you browse to http://localhost (e.g. by adding `wp_die($_SERVER['REMOTE_ADDR']);` to the theme code)
3. Add that IP address to the IP allow list in the members only settings, and set the max age and static max age options to distinct recognisable values
4. In an incognito window, try to access the site. You should be able to access the homepage without being redirected to the login form, and the cache-control max age header should be set to the static max age value (i.e. the incorrect value for your request)
5. Checkout this branch of the plugin, and repeat the request. It should now return the standard max age value.

I haven't been able to check locally that the correct static max age is being served for uploads, as that requires getting requests to `wp-uploads/` to be redirected via `/index.php`, and I haven't been able to make that work. But it looks like it should work 🤷 
