### PR TITLE
Chore/add scripts to rule them all

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,9 +23,5 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
-      - name: Install dependencies
-        run: composer --no-interaction install
-      - name: PHP CS fix
-        run: vendor/bin/php-cs-fixer fix --dry-run -v --diff
-      - name: Run Psalm
-        run: ./vendor/bin/psalm --error-level=1 --find-unused-psalm-suppress
+      - name: Run tests
+        run: script/test

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# script/bootstrap: Resolve all dependencies that the application requires to
+#                   run.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -z "$CI" ]; then
+  if [ -f Brewfile ] && [ "$(uname -s)" = "Darwin" ]; then
+    if ! brew bundle check >/dev/null 2>&1; then
+      echo "==> Installing Homebrew dependencies..."
+      brew bundle install --verbose
+    fi
+  fi
+fi
+
+if [ -f composer.json ]; then
+  if ! bundle check >/dev/null 2>&1; then
+    echo "==> Installing PHP dependencies..."
+    if [ -z "$CI" ]; then
+      composer install
+    else
+      composer install --no-interaction
+    fi
+  fi
+fi

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# script/setup: Set up the application for the first time after cloning, or set
+#               it back to the initial unused state.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -f composer.json ] && [ -d vendor ]; then
+  echo "==> Cleaning installed PHP dependencies..."
+  git clean -x --force -- vendor
+fi
+
+echo "==> Bootstrapping..."
+script/bootstrap

--- a/script/test
+++ b/script/test
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# script/test: Run the test suite for the application.
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -n "$DEBUG" ]; then
+  set -x
+fi
+
+echo "==> Updating..."
+script/update
+
+echo "==> Running php-cs-fixer..."
+vendor/bin/php-cs-fixer fix --dry-run -v --diff
+
+echo "==> Running static code analysis..."
+vendor/bin/psalm --error-level=1 --find-unused-psalm-suppress --no-cache

--- a/script/update
+++ b/script/update
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# script/update: Update the application to run for its current checkout.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Bootstrapping..."
+script/bootstrap


### PR DESCRIPTION
This PR adds the [scripts-to-rule-them-all pattern](https://github.com/github/scripts-to-rule-them-all), to ease plugin development.

## How to test

1. Run `script/test` - the latest dependencies should be installed, then PHP CS Fixer and Psalm should run, and all tests should pass.