### PR TITLE
Chore/add local test site

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,9 +23,5 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
-      - name: Install dependencies
-        run: composer --no-interaction install
-      - name: PHP CS fix
-        run: vendor/bin/php-cs-fixer fix --dry-run -v --diff
-      - name: Run Psalm
-        run: ./vendor/bin/psalm --error-level=1 --find-unused-psalm-suppress
+      - name: Run tests
+        run: script/test

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -1,0 +1,24 @@
+name: dxw_members_only
+services:
+
+  wordpress:
+    image: thedxw/wpc-wordpress:php8.2
+    ports:
+      - "80:80"
+    links:
+      - mysql
+    volumes:
+      - ../:/usr/src/app
+      - ../:/var/www/html/wp-content/plugins/dxw-members-only
+  mysql:
+    image: mariadb:10
+    ports:
+      - "3306:3306"
+    environment:
+       MYSQL_ROOT_PASSWORD: foobar
+       MYSQL_DATABASE: wordpress
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+volumes:
+  mysql_data:

--- a/local/setup/internal.sh
+++ b/local/setup/internal.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+# This code will be run during setup, INSIDE the container.
+
+##############
+# Config
+##############
+title="dxw Members Only"
+
+wp db reset --yes
+
+wp core install --skip-email --admin_user=admin --admin_password=admin --admin_email=admin@localhost.invalid --url=http://localhost --title="$title"
+
+wp theme activate twentytwentyfive
+
+wp plugin activate dxw-members-only
+
+wp core update-db

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# script/bootstrap: Resolve all dependencies that the application requires to
+#                   run.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -z "$CI" ]; then
+  if [ -f Brewfile ] && [ "$(uname -s)" = "Darwin" ]; then
+    if ! brew bundle check >/dev/null 2>&1; then
+      echo "==> Installing Homebrew dependencies..."
+      brew bundle install --verbose
+    fi
+  fi
+fi
+
+if [ -f composer.json ]; then
+  if ! bundle check >/dev/null 2>&1; then
+    echo "==> Installing PHP dependencies..."
+    if [ -z "$CI" ]; then
+      composer install
+    else
+      composer install --no-interaction
+    fi
+  fi
+fi

--- a/script/console
+++ b/script/console
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+exec docker-compose -f local/docker-compose.yml exec wordpress bash

--- a/script/server
+++ b/script/server
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+if test "$1" = "down"; then
+	docker compose -f local/docker-compose.yml down
+	exit
+fi
+
+docker compose -f local/docker-compose.yml down --remove-orphans
+
+docker compose -f local/docker-compose.yml pull wordpress
+
+if test "$1" = "-d"; then
+	docker compose -f local/docker-compose.yml up -d
+else
+	docker compose -f local/docker-compose.yml up
+fi

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# script/setup: Set up the application for the first time after cloning, or set
+#               it back to the initial unused state.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -f composer.json ] && [ -d vendor ]; then
+  echo "==> Cleaning installed PHP dependencies..."
+  git clean -x --force -- vendor
+fi
+
+echo "==> Bootstrapping..."
+script/bootstrap

--- a/script/setup
+++ b/script/setup
@@ -14,3 +14,22 @@ fi
 
 echo "==> Bootstrapping..."
 script/bootstrap
+
+# Check if services running
+already_running=1
+if ! docker compose -f local/docker-compose.yml ps | grep -q Up; then
+	script/server -d
+	already_running=0
+fi
+
+# Wait for the MySQL container to be ready
+while ! docker compose -f local/docker-compose.yml exec wordpress mysqladmin ping -hmysql -pfoobar --silent >/dev/null; do
+	echo "===> Waiting for MySQL instance to be ready..."
+	sleep 5
+done
+
+docker compose -f local/docker-compose.yml exec wordpress /usr/src/app/local/setup/internal.sh
+
+if [ $already_running != 1 ]; then
+	docker compose -f local/docker-compose.yml down
+fi

--- a/script/test
+++ b/script/test
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# script/test: Run the test suite for the application.
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -n "$DEBUG" ]; then
+  set -x
+fi
+
+echo "==> Updating..."
+script/update
+
+echo "==> Running php-cs-fixer..."
+vendor/bin/php-cs-fixer fix --dry-run -v --diff
+
+echo "==> Running static code analysis..."
+vendor/bin/psalm --error-level=1 --find-unused-psalm-suppress --no-cache

--- a/script/update
+++ b/script/update
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# script/update: Update the application to run for its current checkout.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Bootstrapping..."
+script/bootstrap


### PR DESCRIPTION
Merge #50 first.

This PR adds a small local test site, to a) assist with manual testing when working on the plugin; and b) to allow for the addition of end-to-end tests in a future PR.

## How to test

1. Run `script/setup && script/server -d`
2. Visit http://localhost/wp-login.php, and login with `admin`/`admin`. Confirm the dxw-members-only plugin is activated, and you can visit the frontend of the site when logged in.