### PR TITLE
Chore/upload support in local env

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,10 @@ content.
 To create a development build:
 1. Run `composer install` to download dependencies
 
-### Testing locally
+### Manual local testing
 
-1. Install and activate this plugin on a development site
-2. Ensure that requests to `wp-content/uploads` are redirected via PHP as follows (otherwise the plugin will not serve any cache headers for media library files):
-   * Access the WordPress container (usually `script/console` for most of our projects)
-   * `cd /etc/apache2/sites-enabled`
-   * `vi wordpress.conf`, and add the following rewrite rule:
-      ```
-      RewriteRule ^wp-content/uploads/.* index.php [L]
-      ```
-   * Save & exit vi, then `service apache2 reload`
-3. If you want to allow-list your local IP address within the plugin, add `0.0.0.0/0` to the IP allow list in the plugin settings page (this has the effect of allow-listing all IP addresses)
+1. Run `script/setup` && `script/server` to spin up a local dev site, running the plugin. The site is at http://localhost, with username and password of `admin`. 
+2. If you want to allow-list your local IP address within the plugin, add `0.0.0.0/0` to the IP allow list in the dxw Members Only settings page (this has the effect of allow-listing all IP addresses)
 
 ## Versioning
 

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     volumes:
       - ../:/usr/src/app
       - ../:/var/www/html/wp-content/plugins/dxw-members-only
+      - ./uploads/:/var/www/html/wp-content/uploads
   mysql:
     image: mariadb:10
     ports:

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ../:/usr/src/app
       - ../:/var/www/html/wp-content/plugins/dxw-members-only
       - ./uploads/:/var/www/html/wp-content/uploads
+      - ./wordpress.conf:/etc/apache2/sites-enabled/wordpress.conf
   mysql:
     image: mariadb:10
     ports:

--- a/local/uploads/.gitignore
+++ b/local/uploads/.gitignore
@@ -1,0 +1,3 @@
+# ignore all files except .gitignore :
+*
+!.gitignore

--- a/local/wordpress.conf
+++ b/local/wordpress.conf
@@ -1,0 +1,17 @@
+<Directory /var/www/html/>
+        RewriteEngine On
+        RewriteBase /
+        RewriteRule ^index\.php$ - [L]
+
+        # add a trailing slash to /wp-admin
+        RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,L]
+        # route upload requests via the WordPress app
+        RewriteRule ^wp-content/uploads/.* index.php [L]
+
+        RewriteCond %{REQUEST_FILENAME} -f [OR]
+        RewriteCond %{REQUEST_FILENAME} -d
+        RewriteRule ^ - [L]
+        RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
+        RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [L]
+        RewriteRule . index.php [L]
+</Directory>


### PR DESCRIPTION
This PR modifies the local dev server so that:

a) it's possible to upload files to the media library (which previously resulted in a permission error)
b) dxw Members Only can control access to (and cache headers of) any uploaded file

## How to test

1. Spin up the local site using `script/setup && script/server -d`
2. Log into the site at http://localhost/wp-login.php and confirm you can upload a file to the media library, and view that file via its URL
3. Try accessing the same URL when not logged in, and you should be redirected to the login page
