### PR TITLE
Chore/run unit tests in script test

### DIFF
--- a/script/test
+++ b/script/test
@@ -15,6 +15,9 @@ script/update
 echo "==> Running php-cs-fixer..."
 vendor/bin/php-cs-fixer fix --dry-run -v --diff
 
+echo "==> Running unit tests..."
+vendor/bin/kahlan spec
+
 echo "==> Running static code analysis..."
 vendor/bin/psalm --error-level=1 --find-unused-psalm-suppress --no-cache
 

--- a/spec/redirect.spec.php
+++ b/spec/redirect.spec.php
@@ -16,7 +16,7 @@ describe(Dxw\MembersOnly\Redirect::class, function () {
 		it('adds the action', function () {
 			allow('add_action')->toBeCalled();
 
-			expect('add_action')->toBeCalled()->once()->with('init', [$this->redirect, 'redirect_request'], -99999999999, 0);
+			expect('add_action')->toBeCalled()->once()->with('init', [$this->redirect, 'handle_request'], -99999999999, 0);
 
 			$this->redirect->register();
 		});


### PR DESCRIPTION
This PR ensures the unit tests are run as part of `script/test`, and fixes the one failing test that had not been spotted because of this omission.